### PR TITLE
Fix dataset path in Kaggle notebook

### DIFF
--- a/Kaggle_1.ipynb
+++ b/Kaggle_1.ipynb
@@ -274,8 +274,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train0 = pd.read_csv('train.csv')\n",
-    "test0 = pd.read_csv('test.csv')"
+    "train0 = pd.read_csv('house-prices-advanced-regression-techniques/train.csv')\n",
+    "test0 = pd.read_csv('house-prices-advanced-regression-techniques/test.csv')"
    ]
   },
   {
@@ -911,7 +911,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>2919 rows × 79 columns</p>\n",
+       "<p>2919 rows \u00d7 79 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -1316,7 +1316,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>2919 rows × 36 columns</p>\n",
+       "<p>2919 rows \u00d7 36 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -1989,7 +1989,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>2919 rows × 79 columns</p>\n",
+       "<p>2919 rows \u00d7 79 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -2381,7 +2381,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>2919 rows × 83 columns</p>\n",
+       "<p>2919 rows \u00d7 83 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -2784,7 +2784,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>2919 rows × 35 columns</p>\n",
+       "<p>2919 rows \u00d7 35 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -3464,7 +3464,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>8 rows × 29 columns</p>\n",
+       "<p>8 rows \u00d7 29 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -4061,7 +4061,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>1459 rows × 321 columns</p>\n",
+       "<p>1459 rows \u00d7 321 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -4459,7 +4459,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>1460 rows × 321 columns</p>\n",
+       "<p>1460 rows \u00d7 321 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -5285,7 +5285,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>1459 rows × 2 columns</p>\n",
+       "<p>1459 rows \u00d7 2 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -5898,7 +5898,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>1459 rows × 2 columns</p>\n",
+       "<p>1459 rows \u00d7 2 columns</p>\n",
        "</div>"
       ],
       "text/plain": [


### PR DESCRIPTION
## Summary
- correct dataset CSV file paths in `Kaggle_1.ipynb`

## Testing
- `python - <<'PY'
import csv
with open('house-prices-advanced-regression-techniques/train.csv') as f:
    r=csv.reader(f)
    print(next(r))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aae476a754832396b95c9361e55184